### PR TITLE
Sequel leaks memory connecting to many databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Links to issues, pull requests or articles demonstrating known memory leaks (gem
 - [sidekiq < 3.5.1](https://github.com/mperham/sidekiq/pull/2598)
 - [therubyracer < 0.12.2](https://github.com/cowboyd/therubyracer/pull/336)
 - [zipruby <= 0.3.6](https://packetstormsecurity.com/files/111242/libzip-0.10-Heap-Overflow-Information-Leak.html)
-- [sequel (if you connect to an arbitrary number of databases)](https://github.com/jeremyevans/sequel/blob/master/lib/sequel/database.rb#L12)
 
 Your Ruby app leaks memory if you see gems above in your _Gemfile.lock_. The list above may save you a week or more of your personal life.
 
@@ -21,6 +20,7 @@ Links to known memory issues (gems are listed alphabetically):
 - [axlsx](https://github.com/randym/axlsx/issues/276)
 - [delayed_job >= 4.06](https://github.com/collectiveidea/delayed_job/issues/776)
 - [newrelic_rpm >= 3.9.4, <= 3.9.7](https://discuss.newrelic.com/t/client-using-large-amount-of-memory/9307)
+- [sequel >= 2.12.0](https://github.com/jeremyevans/sequel/blob/6628380c9d790709c7dc96fade5bfa412e92bb5e/lib/sequel/database.rb#L8). Memory leaks connecting many different databases. [Issue](https://github.com/jeremyevans/sequel/issues/1139).
 
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Links to issues, pull requests or articles demonstrating known memory leaks (gem
 - [sidekiq < 3.5.1](https://github.com/mperham/sidekiq/pull/2598)
 - [therubyracer < 0.12.2](https://github.com/cowboyd/therubyracer/pull/336)
 - [zipruby <= 0.3.6](https://packetstormsecurity.com/files/111242/libzip-0.10-Heap-Overflow-Information-Leak.html)
+- [sequel (if you connect to an arbitrary number of databases)](https://github.com/jeremyevans/sequel/blob/master/lib/sequel/database.rb#L12)
 
 Your Ruby app leaks memory if you see gems above in your _Gemfile.lock_. The list above may save you a week or more of your personal life.
 


### PR DESCRIPTION
Comment from the linked code:

"If you are developing an application that can connect to an arbitrary number of
databases, delete the database objects from this or they will not get
garbage collected."
